### PR TITLE
Fix CVE-2022-0847

### DIFF
--- a/lib/iov_iter.c
+++ b/lib/iov_iter.c
@@ -407,6 +407,7 @@ static size_t copy_page_to_iter_pipe(struct page *page, size_t offset, size_t by
 		return 0;
 
 	buf->ops = &page_cache_pipe_buf_ops;
+	buf->flags = 0;
 	get_page(page);
 	buf->page = page;
 	buf->offset = offset;
@@ -543,6 +544,7 @@ static size_t push_pipe(struct iov_iter *i, size_t size,
 			break;
 
 		buf->ops = &default_pipe_buf_ops;
+		buf->flags = 0;
 		buf->page = page;
 		buf->offset = 0;
 		buf->len = min_t(ssize_t, left, PAGE_SIZE);


### PR DESCRIPTION
See https://dirtypipe.cm4all.com/

I only applied the same changes that have been applied in upstream kernel to fix this serious vulnerability (see https://lore.kernel.org/lkml/20220221100313.1504449-1-max.kellermann@ionos.com/ or https://github.com/torvalds/linux/commit/9d2231c5d74e13b2a0546fee6737ee4446017903)

NB: I've based this PR on the latest branch, even if it has not been touched since August 2021