### PR TITLE
drm: sun4i: hdmi: Fix oops when disabling output

### DIFF
--- a/drivers/gpu/drm/sun4i/sun4i_hdmi_enc.c
+++ b/drivers/gpu/drm/sun4i/sun4i_hdmi_enc.c
@@ -91,7 +91,8 @@ static void sun4i_hdmi_disable(struct drm_encoder *encoder)
 	DRM_DEBUG_DRIVER("Disabling the HDMI Output\n");
 
 #ifdef CONFIG_DRM_SUN4I_HDMI_AUDIO
-	sun4i_hdmi_audio_destroy(hdmi);
+	if (hdmi->hdmi_audio)
+		sun4i_hdmi_audio_destroy(hdmi);
 #endif
 
 	val = readl(hdmi->base + SUN4I_HDMI_VID_CTRL_REG);


### PR DESCRIPTION
If the display does not indicate audio support in the EDID, hdmi->hdmi_audio will be NULL. In this case, we avoid setting up audio output, however we were still attempting to tear it down on disable.

This could lead to a null pointer exception when disabling the output.

Fix the issue by using the same check on tear down as we do on create.